### PR TITLE
Self-managing queue (WIP)

### DIFF
--- a/src/ol/structs/priorityqueue.js
+++ b/src/ol/structs/priorityqueue.js
@@ -24,7 +24,7 @@ ol.structs.PriorityQueue = function(priorityFunction, keyFunction) {
 
   /**
    * @type {function(T): number}
-   * @private
+   * @protected
    */
   this.priorityFunction_ = priorityFunction;
 

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -66,7 +66,10 @@ goog.inherits(ol.TileQueue, ol.structs.PriorityQueue);
 ol.TileQueue.prototype.enqueue = function(element) {
   ol.TileQueue.base(this, 'enqueue', element);
   //Here we kick off the loading piece
-  this.loadMoreTiles_();
+  if (this.loadTimeout_) {
+    clearTimeout(this.loadTimeout_);
+  }
+  this.loadTimeout_ = setTimeout(this.loadMoreTiles_.bind(this), 0);
 }
 
 /**

--- a/src/ol/tilequeue.js
+++ b/src/ol/tilequeue.js
@@ -55,9 +55,19 @@ ol.TileQueue = function(tilePriorityFunction, tileChangeCallback) {
    */
   this.tilesLoading_ = 0;
 
+  this.maxTotalLoading_ = 16;
+
+  this.maxNewLoads_ = 16;
+
 };
 goog.inherits(ol.TileQueue, ol.structs.PriorityQueue);
 
+
+ol.TileQueue.prototype.enqueue = function(element) {
+  ol.TileQueue.base(this, 'enqueue', element);
+  //Here we kick off the loading piece
+  this.loadMoreTiles_();
+}
 
 /**
  * @return {number} Number of tiles loading.
@@ -81,22 +91,43 @@ ol.TileQueue.prototype.handleTileChange = function(event) {
     --this.tilesLoading_;
     this.tileChangeCallback_();
   }
+  this.loadMoreTiles_();
 };
 
 
 /**
- * @param {number} maxTotalLoading Maximum number tiles to load simultaneously.
- * @param {number} maxNewLoads Maximum number of new tiles to load.
+ * Dequeues tiles until the queue is saturated.
+ */
+ol.TileQueue.prototype.loadMoreTiles_ = function() {
+  var maxTotalLoading = this.maxTotalLoading_;
+  var maxNewLoads = this.maxNewLoads_;
+  var newLoads = 0;
+  var tile, tileStruct;
+  while (this.tilesLoading_ < maxTotalLoading && newLoads < maxNewLoads &&
+         this.getCount() > 0) {
+    tileStruct = this.dequeue();
+    var priority = this.priorityFunction_(tileStruct);
+    if (priority != ol.structs.PriorityQueue.DROP) {
+      tile = tileStruct[0];
+      if (tile.getState() === ol.TileState.IDLE) {
+        goog.events.listen(tile, goog.events.EventType.CHANGE,
+            this.handleTileChange, false, this);
+        tile.load();
+        ++this.tilesLoading_;
+        ++newLoads;
+      }
+    }
+  }
+};
+
+
+/**
+ * Maintains the current interface but is now used to set loading thresholds
+ * @param  {number} maxTotalLoading max number of concurrent loading tiles
+ * @param  {number} maxNewLoads     max new tiles to add at each pass
  */
 ol.TileQueue.prototype.loadMoreTiles = function(maxTotalLoading, maxNewLoads) {
-  var newLoads = Math.min(
-      maxTotalLoading - this.getTilesLoading(), maxNewLoads, this.getCount());
-  var i, tile;
-  for (i = 0; i < newLoads; ++i) {
-    tile = /** @type {ol.Tile} */ (this.dequeue()[0]);
-    goog.events.listen(tile, goog.events.EventType.CHANGE,
-        this.handleTileChange, false, this);
-    tile.load();
-  }
-  this.tilesLoading_ += newLoads;
-};
+  this.maxTotalLoading_ = maxTotalLoading;
+  this.maxNewLoads_ = maxNewLoads;
+  this.loadMoreTiles_();
+}

--- a/test/spec/ol/tilequeue.test.js
+++ b/test/spec/ol/tilequeue.test.js
@@ -1,6 +1,8 @@
 goog.provide('ol.test.TileQueue');
 
-describe('ol.TileQueue', function() {
+describe
+
+('ol.TileQueue', function() {
 
   function addRandomPriorityTiles(tq, num) {
     var i, tile, priority;
@@ -12,6 +14,88 @@ describe('ol.TileQueue', function() {
       tq.queuedElements_[tile.getKey()] = true;
     }
   }
+
+  var tileId = 0;
+  function createImageTile() {
+    ++tileId;
+    var tileCoord = [tileId, tileId, tileId];
+    var state = ol.TileState.IDLE;
+    var src = 'data:image/gif;base64,R0lGODlhAQABAPAAAP8AAP///' +
+        'yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==#' + tileId;
+
+    return new ol.ImageTile(tileCoord, state, src, null,
+        ol.source.Image.defaultImageLoadFunction);
+  }
+
+  describe('enqueue()', function() {
+
+    var noop = function() {};
+
+    it('Enqueues the tiles and loads them', function(done) {
+      var q = new ol.TileQueue(noop, noop);
+
+      var numTiles = 20;
+      var maxLoading = 2;
+      var maxNewLoads = 2;
+
+      q.loadMoreTiles(maxLoading, maxNewLoads);
+
+      for (var i = 0; i < numTiles; ++i) {
+        var tile = createImageTile();
+        q.enqueue([tile]);
+      }
+
+      expect(q.getCount()).to.equal(numTiles - Math.min(maxLoading, maxNewLoads));
+      expect(q.getTilesLoading()).to.equal(Math.min(maxLoading, maxNewLoads));
+
+      setTimeout(function() {
+
+        expect(q.getCount()).to.equal(0);
+        expect(q.getTilesLoading()).to.equal(0);
+
+        done();
+      }, 20);
+    });
+  });
+
+  describe('#loadMoreTiles()', function() {
+    var noop = function() {};
+
+    it('works when tile queues share tiles', function(done) {
+      var q1 = new ol.TileQueue(noop, noop);
+      var q2 = new ol.TileQueue(noop, noop);
+
+      var maxLoading = 2;
+      var maxNewLoads = 2;
+
+      q1.loadMoreTiles(maxLoading, maxNewLoads);
+      q2.loadMoreTiles(maxLoading, maxNewLoads);
+
+      var numTiles = 20;
+      for (var i = 0; i < numTiles; ++i) {
+        var tile = createImageTile();
+        q1.enqueue([tile]);
+        q2.enqueue([tile]);
+      }
+
+      // Since loading starts immediately, some tiles will be loading
+      expect(q1.getCount()).to.equal(numTiles - Math.min(maxLoading, maxNewLoads));
+      expect(q2.getCount()).to.equal(numTiles - (Math.min(maxLoading, maxNewLoads) * 2));
+
+      // let all tiles load
+      setTimeout(function() {
+        expect(q1.getTilesLoading()).to.equal(0);
+        expect(q2.getTilesLoading()).to.equal(0);
+
+        expect(q1.getCount()).to.equal(0);
+        expect(q2.getCount()).to.equal(0);
+
+        done();
+      }, 20);
+
+    });
+
+  });
 
   describe('heapify', function() {
     it('does convert an arbitrary array into a heap', function() {


### PR DESCRIPTION
This is a work in progress implementation of a self-managing queue. The loadMoreTiles call has been repurposed to function as a way to set a max loading threshold. 
It will be interesting to see whether this implementation provides for faster tile downloading. 

How it works:

The tile queue has a private method (loadMoreTiles_) which is invoked every time a tile is queued as well as every time a tile loads. This method ensures that the queue is always operating at its maximum capacity. The queue's capacity is set by the repurposed loadMoreTiles(maxLoading, maxNewLoads) method. 
As tiles are dequeued, the queue checks for:
- the tile's priority. 
- the tile's state

If the priority is DROP, the dequeued tile is ignored, and the queue moves on to the next one. If the state is anything other than IDLE, the tile is ignored as well.

Repurposing the loadMoreTiles call is temporary and was done to not impact other code. It is to be noted, however, that there is only one occurrence of a call to this method (in Map) [in the raster branch there are 2] so the change is minimal. 

This implementation would also allow for exposing methods such as "pause" and "resume" on the queue, which could provide interesting functionality. 
